### PR TITLE
Apostrophes fix for RU translation

### DIFF
--- a/Language/values-ru/strings.xml
+++ b/Language/values-ru/strings.xml
@@ -2,7 +2,7 @@
 
 <resources>
     <string name="app_name">Soul</string>
-    <string name="notice">Нажав кнопку \'Начать работу\', вы соглашаетесь с %1$s и %2$s браузера Soul.</string>
+    <string name="notice">Нажав кнопку «Начать работу», вы соглашаетесь с %1$s и %2$s браузера Soul.</string>
     <string name="notice_tos">Условия использования</string>
     <string name="notice_privacy">Политика конфиденциальности</string>
     <string name="start">Начать работу</string>
@@ -236,13 +236,13 @@
     <string name="delete_cookie">Удалить файлы cookie</string>
     <string name="screen_rotate">Ориентация экрана</string>
     <string name="vol_scroll">Прокрутка страниц с помощью клавиш громкости</string>
-    <string name="double_back">Дважды нажмите кнопку \'Назад\', чтобы выйти из приложения</string>
+    <string name="double_back">Дважды нажмите кнопку «Назад», чтобы выйти из приложения</string>
     <string name="press_again">Нажмите еще раз, чтобы выйти</string>
     <string name="last_noti">Уведомление о последней странице</string>
-    <string name="last_noti_info">При нажатии кнопки \'Назад\' на последней странице вкладки, появится уведомление.</string>
+    <string name="last_noti_info">При нажатии кнопки «Назад» на последней странице вкладки, появится уведомление.</string>
     <string name="last_page_noti">Это последняя страница вкладки</string>
     <string name="last_swipe">Закрывать свайпом вкладку с последней страницы</string>
-    <string name="last_exit">Поведение кнопки \'Назад\' на последней странице</string>
+    <string name="last_exit">Поведение кнопки «Назад» на последней странице</string>
     <string name="title">Заголовок</string>
     <string name="author">Автор</string>
     <string name="artist">Исполнитель</string>
@@ -357,7 +357,7 @@
     <string name="ask_rem_pms">Удалить разрешение на доступ к аккаунту?</string>
     <string name="remove_pms">Удалить разрешение</string>
     <string name="noti_pms">Разрешение на уведомления</string>
-    <string name="noti_pms_guide_1">\'Разрешение на уведомления\' требуется для уведомлений о статусе следующих функций.</string>
+    <string name="noti_pms_guide_1">«Разрешение на уведомления» требуется для уведомлений о статусе следующих функций.</string>
     <string name="ads_block">Блокировщик рекламы</string>
     <string name="ads_block_info">Для блокировки рекламы должен быть активен хотя бы один фильтр.</string>
     <string name="filtered_image">Отфильтровано изображений (%d)</string>
@@ -517,7 +517,7 @@
     <string name="reinput">Пожалуйста, введите еще раз</string>
     <string name="wrong_input">Неверный ввод</string>
     <string name="continue_input">Продолжить</string>
-    <string name="pip_home">Переключаться в режим PIP с помощью кнопки \'Домой\'</string>
+    <string name="pip_home">Переключаться в режим PIP с помощью кнопки «Домой»</string>
     <string name="memory_warning_1">Эта функция использует больше памяти.</string>
     <string name="secret_data_info">Разделение данных (cookie, кэш и т.д.) поддерживается начиная с Android 9.</string>
     <string name="secret_hist">Сохранять историю посещений</string>
@@ -593,7 +593,7 @@
     <string name="icon_color">Цвет кнопки</string>
     <string name="icon_pos">Расположение кнопки</string>
     <string name="storage_guide_1">Обновлено для Android 10.</string>
-    <string name="storage_guide_2">Начиная с Android 10 применяется политика \'Scoped storage\'.</string>
+    <string name="storage_guide_2">Начиная с Android 10 применяется политика «Scoped storage».</string>
     <string name="storage_guide_3">Список хранилищ и путь хранения были сброшены.</string>
     <string name="storage_guide_4">Файлы сохраняются.</string>
     <string name="not_selected">Не выбрано</string>
@@ -810,7 +810,7 @@
     <string name="only_https">Подключаться по HTTPS</string>
     <string name="only_https_info">По умолчанию подключаться по протоколу HTTPS.\nСайты, не поддерживающие HTTPS, могут не загрузиться.</string>
     <string name="http_warning">На HTTP-сайтах (не защищенных сайтах) выполнение невозможно.</string>
-    <string name="page_home_info">При нажатии на на иконку \'Домой\'</string>
+    <string name="page_home_info">При нажатии на на иконку «Домой»</string>
     <string name="page_start_info">При запуске приложения</string>
     <string name="page_tab_info">При создании новой вкладки</string>
     <string name="filter_user_1">Вы можете добавить фильтры для блокировки большего количества рекламы.</string>
@@ -1027,8 +1027,8 @@
     <string name="area_edit_guide_4">Но не переживайте.</string>
     <string name="area_edit_guide_5">Вы всегда сможете отредактировать его снова.</string>
     <string name="area_edit_guide_6">Не стесняйтесь попробовать.</string>
-    <string name="area_recom_1">Попробуйте использовать функцию \'%s\'.</string>
-    <string name="area_recom_2">Функция \'%s\' позволяет напрямую выбрать то, что вы хотите заблокировать.</string>
+    <string name="area_recom_1">Попробуйте использовать функцию «%s».</string>
+    <string name="area_recom_2">Функция «%s» позволяет напрямую выбрать то, что вы хотите заблокировать.</string>
     <string name="area_info_1">Сегодня во всемирной паутине насчитывается более 1.5 миллиардов веб-сайтов.</string>
     <string name="area_info_2">Именно поэтому фильтр содержит информацию о многих сайтах.</string>
     <string name="area_info_3">Однако пользователи обычно посещают только несколько сайтов.</string>
@@ -1039,10 +1039,10 @@
     <string name="area_info_8">Чтобы решить эту проблему, вам нужен индивидуальный фильтр, который работает для вас.</string>
     <string name="area_info_9">Однако создание фильтра требует знаний о фильтрах.</string>
     <string name="area_info_10">По этой причине многие пользователи отказываются от создания собственных фильтров.</string>
-    <string name="area_info_11">Функция \'%s\' не требует каких-либо знаний о фильтрах.</string>
+    <string name="area_info_11">Функция «%s» не требует каких-либо знаний о фильтрах.</string>
     <string name="area_info_12">Любой может легко создавать собственные фильтры.</string>
     <string name="area_info_13">Нажмите и удерживайте объект который хотите заблокировать, чтобы открыть меню.</string>
-    <string name="area_info_14">Когда вы запустите и примените функцию \'%s\', фильтр будет создан автоматически.</string>
+    <string name="area_info_14">Когда вы запустите и примените функцию «%s», фильтр будет создан автоматически.</string>
     <string name="area_info_15">Это очень легко.</string>
     <string name="area_info_16">Попробуйте прямо сейчас.</string>
     <string name="freq_asked">Часто задаваемые вопросы</string>


### PR DESCRIPTION
In Russian and Ukrainian languages, it is customary to use **«»** (guillemets) or **"** (double quotation marks) for quotations and dialogue instead of ' (apostrophes). This practice has historical and typographical roots in these languages, as guillemets and quotation marks are specifically designed for this purpose and help distinguish quotes from other text elements. Using guillemets or quotation marks ensures better readability and prevents confusion with other punctuation marks, such as apostrophes, which are often used for contractions or possessive forms. The application should compile without issues when using **«»** or " instead of `/'`.